### PR TITLE
Make root project a library to allow jfrog publishing [patch]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("no.elhub.devxp.kotlin-core") version "0.2.3"
+    id("no.elhub.devxp.kotlin-library") version "0.2.3"
     `maven-publish`
 }
 


### PR DESCRIPTION
## 📝 Description

kotlin-core plugin does not have artifactory setup, so this led to nothing being published

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
