### PR TITLE
Remove artifactoryRepository param from tc pipeline [patch]

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,13 +1,11 @@
 import jetbrains.buildServer.configs.kotlin.ArtifactRule
 import no.elhub.devxp.build.configuration.pipeline.ElhubProject.Companion.elhubProject
 import no.elhub.devxp.build.configuration.pipeline.constants.Group.DEVXP
-import no.elhub.devxp.build.configuration.pipeline.constants.ArtifactoryRepository
 import no.elhub.devxp.build.configuration.pipeline.jobs.gradleAutoRelease
 import no.elhub.devxp.build.configuration.pipeline.jobs.gradleVerify
 
 elhubProject(DEVXP, "devxp-auto-changelog") {
     val gradleModules = listOf("core", "cli")
-    val artifactoryRepository = ArtifactoryRepository.ELHUB_BIN_RELEASE_LOCAL
 
     pipeline {
         sequential {
@@ -17,9 +15,7 @@ elhubProject(DEVXP, "devxp-auto-changelog") {
                 buildArtifactRules = gradleModules.map { ArtifactRule.include("$it/build", "$it/build.zip") }
                 outputArtifactRules = gradleModules.map { ArtifactRule.include("$it/build.zip!**", "$it/build") }
             }
-            gradleAutoRelease(artifacts = listOf(artifacts)) {
-                repository = artifactoryRepository
-            }
+            gradleAutoRelease(artifacts = listOf(artifacts))
         }
     }
 }


### PR DESCRIPTION
## 📝 Description

The gradle publish command should sort this out automatically. In the current behavior this setting seems to override the per-module settings, which is not ideal.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
