### PR TITLE
Update to use this repo for testing instead of old bitbucket repo

### DIFF
--- a/core/src/test/kotlin/no/elhub/devxp/autochangelog/extensions/GitExtensionsTest.kt
+++ b/core/src/test/kotlin/no/elhub/devxp/autochangelog/extensions/GitExtensionsTest.kt
@@ -10,30 +10,22 @@ class GitExtensionsTest : FunSpec({
     val git = GitRepo(TestRepository.git)
 
     test("should return the title of the commit") {
-        val commit = git.findCommit(ObjectId.fromString("a40cacb9c7d2f8996789498494583e78d611b174"))
-        commit?.title shouldBe "Bump middleman from 4.3.11 to 4.4.0 (#401)"
+        val commit = git.findCommit(ObjectId.fromString("f13fe0137c9c239cfc66da4fc1a238a2dabf586b"))
+        commit?.title shouldBe "Bump devxp-build-config version for tc upgrade"
     }
 
     test("should return the detailed description of the commit") {
-        val commit = git.findCommit(ObjectId.fromString("a40cacb9c7d2f8996789498494583e78d611b174"))
+        val commit = git.findCommit(ObjectId.fromString("f13fe0137c9c239cfc66da4fc1a238a2dabf586b"))
         commit?.description shouldBe """
-            Bumps [middleman](https://github.com/middleman/middleman) from 4.3.11 to 4.4.0.
-            - [Release notes](https://github.com/middleman/middleman/releases)
-            - [Changelog](https://github.com/middleman/middleman/blob/v4.4.0/CHANGELOG.md)
-            - [Commits](https://github.com/middleman/middleman/compare/v4.3.11...v4.4.0)
-            ---
-            updated-dependencies:
-            - dependency-name: middleman
-                dependency-type: direct:production
-                update-type: version-update:semver-minor
-            ...
-            Signed-off-by: dependabot[bot] <support@github.com>
-            Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+            ## 🔗 Issue ID(s): TDX-811
+            ## 📋 Checklist
+            * ✅ Lint checks passed on local machine.
+            * ✅ Unit tests passed on local machine.
         """.trimIndent().split("\n").map { it.trim() }
     }
 
     test("should return an empty list for commits that only have titles") {
-        val commit = git.findCommit(ObjectId.fromString("2ea214c6f40eb002b086475910a0948fbf2e5dac"))
+        val commit = git.findCommit(ObjectId.fromString("aa711042e58828bd4259eee9edde42d0d539272f"))
         commit?.description shouldBe emptyList()
     }
 })

--- a/core/src/test/kotlin/no/elhub/devxp/autochangelog/io/ChangelogReaderTest.kt
+++ b/core/src/test/kotlin/no/elhub/devxp/autochangelog/io/ChangelogReaderTest.kt
@@ -17,8 +17,8 @@ class ChangelogReaderTest : FunSpec({
         test("should return latest released version from the changelog file") {
             val version: SemanticVersion? = changelog.lastRelease
             assertSoftly {
-                version?.major shouldBe 1
-                version?.minor shouldBe 1
+                version?.major shouldBe 0
+                version?.minor shouldBe 5
                 version?.patch shouldBe 0
             }
         }

--- a/core/src/test/kotlin/no/elhub/devxp/autochangelog/project/GitRepoTest.kt
+++ b/core/src/test/kotlin/no/elhub/devxp/autochangelog/project/GitRepoTest.kt
@@ -24,32 +24,32 @@ class GitRepoTest : FunSpec({
         context("git log") {
 
             test("should return git ref for a given version") {
-                repo.findTagRef(SemanticVersion(1, 1, 0))?.name shouldBe "refs/tags/v1.1.0"
+                repo.findTagRef(SemanticVersion(0, 3, 6))?.name shouldBe "refs/tags/v0.3.6"
             }
 
             test("should find a commit for a given ref") {
-                val c = repo.findCommitId(SemanticVersion(1, 1, 0))?.let {
+                val c = repo.findCommitId(SemanticVersion(0, 4, 0))?.let {
                     repo.findCommit(it)
                 }
-                c?.shortMessage shouldStartWith "Merge pull request #197"
+                c?.shortMessage shouldStartWith "Fix errors in publishing configuration"
             }
 
             test("should find a parent for a given ref") {
-                val c = repo.findCommitId(SemanticVersion(1, 1, 0))?.let {
+                val c = repo.findCommitId(SemanticVersion(0, 4, 0))?.let {
                     repo.findParent(it)
                 }
-                c?.shortMessage shouldBe "Bump Ruby version to 2.4"
+                c?.shortMessage shouldBe "Merge pull request #19 from elhub/feat/add-renovate-config"
             }
 
             test("should return a log of commit ranges") {
-                val end = ObjectId.fromString("5f06962bf9a484a35a3a37c24f3933a9168e90ff")
-                val start = ObjectId.fromString("c25aae9ec630c546999a5cd62740639746efbc13")
+                val end = ObjectId.fromString("a10802f208e915bfaf6466a00fc64898bbba9fa1")
+                val start = ObjectId.fromString("82bb30a5e56245734a6ff166777d605615cb4010")
 
                 repo.log(start, end).toList() shouldHaveSize 7
             }
 
             test("should return entire log") {
-                repo.log().toList() shouldHaveSize 495
+                repo.log().toList() shouldHaveSize 115
             }
         }
 
@@ -158,10 +158,7 @@ class GitRepoTest : FunSpec({
         test("should generate compare url") {
             val cl = repo.createChangelist(repo.constructLog())
             val writer = ChangelogWriter()
-            writer.generateCompareUrl(
-                changelist = cl,
-                repo = repo
-            ) shouldBe "https://code.elhub.cloud/scm/ext/ext-keep-a-changelog/compare/commits?targetBranch=refs%2Ftags%2Fv1.1.0"
+            writer.generateCompareUrl(cl, repo) shouldBe "https://github.com/elhub/devxp-auto-changelog/compare/v0.5.0...main"
         }
     }
 })

--- a/core/src/test/kotlin/no/elhub/devxp/autochangelog/project/TestRepository.kt
+++ b/core/src/test/kotlin/no/elhub/devxp/autochangelog/project/TestRepository.kt
@@ -2,6 +2,7 @@ package no.elhub.devxp.autochangelog.project
 
 import no.elhub.devxp.autochangelog.extensions.delete
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -13,8 +14,13 @@ object TestRepository {
     val git: Git by lazy {
         Git.cloneRepository()
             .setDirectory(tempFolderPath.toFile())
-            .setURI("https://code.elhub.cloud/scm/ext/ext-keep-a-changelog.git")
-            .call()
+            .setURI("https://github.com/elhub/devxp-auto-changelog.git")
+            .call().apply {
+                reset()
+                    .setMode(ResetCommand.ResetType.HARD)
+                    .setRef("4b898e6")
+                    .call()
+            }
     }
 
     val changelogPath: Path = tempFolderPath.resolve("CHANGELOG.md")


### PR DESCRIPTION
## 📝 Description

This repository used to use an old fork of keep-a-changelog hosted on bitbucket to run tests. Now, we use a previous revision of this repository, which reduces dependency and makes it easier to verify

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
