### PR TITLE
fix: ensure newline for json changelog [patch]

### DIFF
--- a/core/src/main/kotlin/no/elhub/devxp/autochangelog/io/ChangelogWriter.kt
+++ b/core/src/main/kotlin/no/elhub/devxp/autochangelog/io/ChangelogWriter.kt
@@ -53,7 +53,7 @@ class ChangelogWriter {
         }
 
         // If Jira details are included, use JiraChangelogEntry for richer output
-        return if (includeJiraDetails) {
+        val jsonString = if (includeJiraDetails) {
             // Convert each ChangelogEntry to a JiraChangelogEntry with Jira details
             val jiraChangelist = changelist.changes.entries.map { (version, entries) ->
                 entries.map { entry ->
@@ -65,6 +65,7 @@ class ChangelogWriter {
         } else {
             json.encodeToString(changelist.changes.values.flatten())
         }
+        return if (jsonString.endsWith("\n")) jsonString else "$jsonString\n"
     }
 
     private fun write(changelist: Changelist): Writer = start()

--- a/core/src/test/kotlin/no/elhub/devxp/autochangelog/io/TestCases.kt
+++ b/core/src/test/kotlin/no/elhub/devxp/autochangelog/io/TestCases.kt
@@ -62,6 +62,7 @@ val singleExpectedJson = """
             ]
         }
     ]
+
 """.trimIndent()
 
 val doubleChangeList = Changelist(
@@ -168,6 +169,7 @@ val doubleExpectedJson = """
             ]
         }
     ]
+
 """.trimIndent()
 
 val singleChangelogTestMd = TestCase(


### PR DESCRIPTION
## 📝 Description

Without this newline we get a lint error when the changelog is included in a PR

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
