### PR TITLE
refactor: remove unnecessary 'Related Commits' heading [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/autochangelog/features/writer/MarkdownWriter.kt
+++ b/src/main/kotlin/no/elhub/devxp/autochangelog/features/writer/MarkdownWriter.kt
@@ -21,7 +21,6 @@ fun formatMarkdown(jiraIssues: Map<JiraIssue, List<GitCommit>>, strikethrough: B
                 } else {
                     appendLine("## [${jiraIssue.key}]($JIRA_PREFIX${jiraIssue.key}): ${jiraIssue.title}")
                 }
-                appendLine("### Related Commits")
                 commits.forEach { commit ->
                     appendLine("- `${commit.hash}`: ${commit.title}")
                 }

--- a/src/test/kotlin/no/elhub/devxp/autochangelog/features/writer/MarkdownWriterTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/autochangelog/features/writer/MarkdownWriterTest.kt
@@ -66,12 +66,10 @@ class MarkdownWriterTest : FunSpec({
 
             formattedMarkDownWithoutDate shouldBe """
                 ## [ABC-101](https://elhub.atlassian.net/browse/ABC-101): Implement feature X
-                ### Related Commits
                 - `abc123`: Implement feature X
                 - `def456`: Fix bug Y
 
                 ## [ABC-102](https://elhub.atlassian.net/browse/ABC-102): Fix bug Y
-                ### Related Commits
                 - `abc123`: Implement feature X
 
                 ## Commits without associated JIRA issues
@@ -120,7 +118,6 @@ class MarkdownWriterTest : FunSpec({
                 Generated at 2050-06-01
                 ## [1.0.0] - 2024-01-01
                 - Initial release
-                ### Related Commits
                 - `abc123`: Initial commit
             """.trimIndent()
             writeMarkdownToFile(markdownContent, changelogFile.path)


### PR DESCRIPTION
## 📝 Description

This heading just ends up being noise in the changelog, so removing it.

## 🔗 Issue ID(s): [TDX-1386](https://elhub.atlassian.net/browse/TDX-1386)

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.


[TDX-1386]: https://elhub.atlassian.net/browse/TDX-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ